### PR TITLE
Load core libs before spec support files

### DIFF
--- a/spec/support/db.rb
+++ b/spec/support/db.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Base
-  .logger = Logger.new("#{TMP_PATH}/parelation.log")
+  .logger = Logger.new(LOG_PATH)
 ActiveRecord::Base
   .establish_connection(adapter: "sqlite3", database: ":memory:")
 

--- a/spec/support/env.rb
+++ b/spec/support/env.rb
@@ -1,13 +1,15 @@
+require "fileutils"
+require "logger"
+require "pry"
+require "sqlite3"
+require "active_record"
+
 ROOT_PATH = File.expand_path("../../..", __FILE__)
 SPEC_PATH = File.join(ROOT_PATH, "spec")
 TMP_PATH = File.join(ROOT_PATH, "tmp")
 DB_PATH = File.join(TMP_PATH, "parelation.db")
 LOG_PATH = File.join(TMP_PATH, "parelation.log")
+
 FileUtils.mkdir_p(TMP_PATH)
 
-require "pry"
-require "logger"
-require "sqlite3"
-require "active_record"
-require "fileutils"
 require "#{SPEC_PATH}/support/db"


### PR DESCRIPTION
...to fix an error when trying to run specs via `rake` or `rspec`.
