### PR TITLE
Use ActiveRecord to generate queries for specs

### DIFF
--- a/spec/lib/criteria/limit_spec.rb
+++ b/spec/lib/criteria/limit_spec.rb
@@ -13,7 +13,9 @@ describe Parelation::Criteria::Limit do
   end
 
   it "should add criteria to the chain" do
-    expect(klass.new(Ticket.all, "limit", "40").call.to_sql)
-      .to eq(%Q{SELECT  "tickets".* FROM "tickets"  LIMIT 40})
+    criteria = klass.new(Ticket.all, "limit", "40").call
+    ar_query = Ticket.limit(40)
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 end

--- a/spec/lib/criteria/offset_spec.rb
+++ b/spec/lib/criteria/offset_spec.rb
@@ -13,7 +13,9 @@ describe Parelation::Criteria::Offset do
   end
 
   it "should add criteria to the chain" do
-    expect(klass.new(Ticket.all, "offset", "80").call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"  LIMIT -1 OFFSET 80})
+    criteria = klass.new(Ticket.all, "offset", "40").call
+    ar_query = Ticket.offset(40)
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 end

--- a/spec/lib/criteria/order_spec.rb
+++ b/spec/lib/criteria/order_spec.rb
@@ -13,24 +13,24 @@ describe Parelation::Criteria::Order do
   end
 
   it "should add acending order criteria to the chain" do
-    expect(klass.new(Ticket.all, "order", "created_at:asc").call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"   } +
-             %Q{ORDER BY "tickets"."created_at" ASC})
+    criteria = klass.new(Ticket.all, "order", "created_at:asc").call
+    ar_query = Ticket.order(created_at: :asc)
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 
   it "should add descending order criteria to the chain" do
-    expect(klass.new(Ticket.all, "order", "created_at:desc").call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"   } +
-             %Q{ORDER BY "tickets"."created_at" DESC})
+    criteria = klass.new(Ticket.all, "order", "created_at:desc").call
+    ar_query = Ticket.order(created_at: :desc)
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 
-  it "should combined multiple asc and desc order criteria" do
+  it "should combine multiple asc and desc order criteria" do
     orders = %w[created_at:desc name:asc updated_at:desc message:asc]
-    expect(klass.new(Ticket.all, "order", orders).call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"   } +
-             %Q{ORDER BY "tickets"."created_at" DESC, } +
-             %Q{"tickets"."name" ASC, } +
-             %Q{"tickets"."updated_at" DESC, } +
-             %Q{"tickets"."message" ASC})
+    criteria = klass.new(Ticket.all, "order", orders).call
+    ar_query = Ticket.order(created_at: :desc, name: :asc, updated_at: :desc, message: :asc)
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 end

--- a/spec/lib/criteria/query_spec.rb
+++ b/spec/lib/criteria/query_spec.rb
@@ -13,17 +13,19 @@ describe Parelation::Criteria::Query do
   end
 
   it "should add single-column criteria to the chain" do
-    value = { "ruby on rails" => "name" }
-    expect(klass.new(Ticket.all, "query", value).call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-             %Q{WHERE ("tickets"."name" LIKE '%ruby on rails%')})
+    criteria = klass.new(Ticket.all, "query", { "ruby on rails" => "name" }).call
+    ar_query = Ticket.where(%Q{"tickets"."name" LIKE ?}, "%ruby on rails%")
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 
   it "should add multi-column criteria to the chain" do
-    value = { "ruby on rails" => ["name", "message"] }
-    expect(klass.new(Ticket.all, "query", value).call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-             %Q{WHERE ("tickets"."name" LIKE '%ruby on rails%' } +
-             %Q{OR "tickets"."message" LIKE '%ruby on rails%')})
+    criteria = klass.new(Ticket.all, "query", { "ruby on rails" => ["name", "message"] }).call
+    ar_query = Ticket.where(
+      %Q{"tickets"."name" LIKE ? OR "tickets"."message" LIKE ?},
+      "%ruby on rails%", "%ruby on rails%"
+    )
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 end

--- a/spec/lib/criteria/select_spec.rb
+++ b/spec/lib/criteria/select_spec.rb
@@ -13,7 +13,9 @@ describe Parelation::Criteria::Select do
   end
 
   it "should add criteria to the chain" do
-    expect(klass.new(Ticket.all, "select", ["id", "name"]).call.to_sql)
-      .to eq(%Q{SELECT "tickets"."id", "tickets"."name" FROM "tickets"})
+    criteria = klass.new(Ticket.all, "select", ["id", "name"]).call
+    ar_query = Ticket.all.select(:id, :name)
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 end

--- a/spec/lib/criteria/where_spec.rb
+++ b/spec/lib/criteria/where_spec.rb
@@ -13,64 +13,66 @@ describe Parelation::Criteria::Where do
     expect(klass.match?("query")).to eq(false)
   end
 
-  it "should add = criteria to the chain" do
-    sql = %Q{SELECT "tickets".* FROM "tickets"  } +
-          %Q{WHERE "tickets"."state" = 'open'}
+  it "should add = criteria to the chain when argument is a value" do
+    criteria = klass.new(Ticket.all, "where", state: "open").call
+    ar_query = Ticket.where(state: "open")
 
-    instance = klass.new(Ticket.all, "where", state: "open")
-    expect(instance.call.to_sql).to eq(sql)
-
-    instance = klass.new(Ticket.all, "where", state: ["open"])
-    expect(instance.call.to_sql).to eq(sql)
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 
-  it "should add IN criteria to the chain" do
-    value = { state: ["open", "pending"] }
-    expect(klass.new(Ticket.all, "where", value).call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-             %Q{WHERE "tickets"."state" IN ('open', 'pending')})
+  it "should add = criteria to the chain when argument is an array" do
+    criteria = klass.new(Ticket.all, "where", state: ["open"]).call
+    ar_query = Ticket.where(state: "open")
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 
-  it "should add != criteria to the chain" do
-    sql = %Q{SELECT "tickets".* FROM "tickets"  } +
-          %Q{WHERE ("tickets"."state" != 'open')}
+  it "should add IN criteria to the chain when values are many" do
+    criteria = klass.new(Ticket.all, "where", state: ["open", "pending"]).call
+    ar_query = Ticket.where(state: ["open", "pending"])
 
-    instance = klass.new(Ticket.all, "where_not", state: "open")
-    expect(instance.call.to_sql).to eq(sql)
-
-    instance = klass.new(Ticket.all, "where_not", state: ["open"])
-    expect(instance.call.to_sql).to eq(sql)
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 
-  it "should add NOT IN criteria to the chain" do
-    value = { state: ["open", "pending"] }
-    expect(klass.new(Ticket.all, "where_not", value).call.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-             %Q{WHERE ("tickets"."state" NOT IN ('open', 'pending'))})
+  it "should add != criteria to the chain when argument is a value" do
+    criteria = klass.new(Ticket.all, "where_not", state: "open").call
+    ar_query = Ticket.where.not(state: "open")
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
+  end
+
+  it "should add != criteria to the chain when argument is an array" do
+    criteria = klass.new(Ticket.all, "where_not", state: "open").call
+    ar_query = Ticket.where.not(state: "open")
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
+  end
+
+  it "should add NOT IN criteria to the chain when values are many" do
+    criteria = klass.new(Ticket.all, "where_not", state: ["open", "pending"]).call
+    ar_query = Ticket.where.not(state: ["open", "pending"])
+
+    expect(criteria.to_sql).to eq(ar_query.to_sql)
   end
 
   [%w[where_gt >], %w[where_gte >=], %w[where_lt <], %w[where_lte <=]]
     .each do |(operator, symbol)|
 
     it "should add #{symbol} criteria to the chain" do
-      value = { created_at: "2014-08-26T19:20:44Z" }
-      instance = klass.new(Ticket.all, operator, value)
+      criteria = klass.new(Ticket.all, operator, created_at: "2014-08-26T19:20:44Z").call
+      ar_query = Ticket.where(
+        %Q{"tickets".'created_at' #{symbol} ?}, "2014-08-26 19:20:44.000000"
+      )
 
-      expect(instance.call.to_sql)
-        .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-               %Q{WHERE ("tickets".'created_at' #{symbol} } +
-               %Q{'2014-08-26 19:20:44.000000')})
+      expect(criteria.to_sql).to eq(ar_query.to_sql)
     end
 
     it "should add multiple #{symbol} criteria to the chain" do
-      value = { created_at: "2014-08-26T19:20:44Z", position: "5" }
-      instance = klass.new(Ticket.all, operator, value)
+      criteria = klass.new(Ticket.all, operator, created_at: "2014-08-26T19:20:44Z", position: "5").call
+      ar_query = Ticket.where(%Q{"tickets".'created_at' #{symbol} ?}, "2014-08-26 19:20:44.000000")
+                       .where(%Q{"tickets".'position' #{symbol} ?}, 5)
 
-      expect(instance.call.to_sql).to eq(
-        %Q{SELECT "tickets".* FROM "tickets"  } +
-        %Q{WHERE ("tickets".'created_at' #{symbol} '2014-08-26 19:20:44.000000') } +
-        %Q{AND ("tickets".'position' #{symbol} 5)}
-      )
+      expect(criteria.to_sql).to eq(ar_query.to_sql)
     end
   end
 
@@ -98,10 +100,7 @@ describe Parelation::Criteria::Where do
     it "should not override foreign key, nor yield results" do
       chain = klass.new(@project1.tickets, "where", project_id: @project2.id).call
       expect(chain.count).to eq(0)
-      expect(chain.to_sql)
-        .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-               %Q{WHERE "tickets"."project_id" = ? } +
-               %Q{AND "tickets"."project_id" = #{@project2.id}})
+      expect(chain.to_sql).to eq(@project1.tickets.where(project_id: @project2.id).to_sql)
     end
   end
 
@@ -109,17 +108,19 @@ describe Parelation::Criteria::Where do
 
     ["1", "t", "true"].each do |string_bool|
       it "should cast #{string_bool} to true" do
-        expect(klass.new(Ticket.all, "where", resolved: string_bool).call.to_sql)
-          .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-                 %Q{WHERE "tickets"."resolved" = 't'})
+        criteria = klass.new(Ticket.all, "where", resolved: string_bool).call
+        ar_query = Ticket.where(resolved: true)
+
+        expect(criteria.to_sql).to eq(ar_query.to_sql)
       end
     end
 
     ["0", "f", "false"].each do |string_bool|
       it "should cast #{string_bool} to false" do
-        expect(klass.new(Ticket.all, "where", resolved: string_bool).call.to_sql)
-          .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-                 %Q{WHERE "tickets"."resolved" = 'f'})
+        criteria = klass.new(Ticket.all, "where", resolved: string_bool).call
+          ar_query = Ticket.where(resolved: false)
+
+          expect(criteria.to_sql).to eq(ar_query.to_sql)
       end
     end
   end
@@ -127,27 +128,30 @@ describe Parelation::Criteria::Where do
   describe "casting:integer" do
 
     it "should cast a string to integer" do
-      expect(klass.new(Ticket.all, "where", position: "5").call.to_sql)
-        .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-               %Q{WHERE "tickets"."position" = 5})
+      criteria = klass.new(Ticket.all, "where", position: "5").call
+      ar_query = Ticket.where(position: 5)
+
+      expect(criteria.to_sql).to eq(ar_query.to_sql)
     end
   end
 
   describe "casting:float" do
 
     it "should cast a string to float" do
-      expect(klass.new(Ticket.all, "where", rating: "2.14").call.to_sql)
-        .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-               %Q{WHERE "tickets"."rating" = 2.14})
+      criteria = klass.new(Ticket.all, "where", rating: "2.14").call
+      ar_query = Ticket.where(rating: 2.14)
+
+      expect(criteria.to_sql).to eq(ar_query.to_sql)
     end
   end
 
   describe "casting:datetime" do
 
     it "should cast a string to time" do
-      expect(klass.new(Ticket.all, "where", created_at: "2014-01-01T00:00:00Z").call.to_sql)
-        .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-               %Q{WHERE "tickets"."created_at" = '2014-01-01 00:00:00.000000'})
+      criteria = klass.new(Ticket.all, "where", created_at: "2014-01-01T00:00:00Z").call
+      ar_query = Ticket.where(created_at: '2014-01-01 00:00:00.000000')
+
+      expect(criteria.to_sql).to eq(ar_query.to_sql)
     end
   end
 end

--- a/spec/lib/helpers_spec.rb
+++ b/spec/lib/helpers_spec.rb
@@ -16,7 +16,6 @@ describe Parelation::Helpers do
 
   it "should parelate the ticket criteria chain" do
     expect(ExampleController.new.index.to_sql)
-      .to eq(%Q{SELECT "tickets".* FROM "tickets"  } +
-             %Q{WHERE "tickets"."state" = 'open'})
+      .to eq(Ticket.all.where(state: 'open').to_sql)
   end
 end


### PR DESCRIPTION
First of all, congratulations for the project as I find it very interesting.

Today I had the opportunity to dig a bit into the source code and in this Pull–Request you'll find out my thoughts, specifically about tests.

Parelation is about converting an HTTP request into a suitable ActiveRecord query, but the tests didn't reflect that. The highlight was more on the SQL, rather than showing which query the library should have come up with.

So, here's what I made:
1. First, I tried to give specs a better structure so that it's easy to recognize the input and the output (`criteria` and `ar_query` variables make this contrast really evident)
2. I constructed the queries via ActiveRecord API, calling `to_sql` after the query building

I believe the code has improved and to me it feels more readable. One added benefit is that, in this way, your tests won't break if there's some change in the way ActiveRecord construct queries.

What do you think? :smile: 
